### PR TITLE
if wayland use ydotool instead of xdotool

### DIFF
--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -146,7 +146,7 @@ done
 outputfile_autostart_script=$( cat << EOF 
 #!/bin/bash
 firefox --url \"$urlq\" &
-sleep 3;\n
+sleep 5;\n
 EOF
 )
 

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,9 +196,12 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				echo $XDG_SESSION_TYPE
+				echo "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'"
 				echo "."
-				echo "$XDG_SESSION_TYPE"
+				echo "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | sed 's/Type=//'"
+				echo ".."
+				SESSION_TYPE=$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}')
+				echo $SESSION_TYPE
 				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,11 +196,12 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				echo loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'
+				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$USERNAME" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
+				echo $SESSION_TYPE
 				echo "."
-				echo loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | sed 's/Type=//'
+				echo $(loginctl show-session $(awk -v u="$USERNAME" '$0 ~ u{ print $1}'<<<$(loginctl)) -p Type | awk -F= '{print $2}')
 				echo ".."
-				SESSION_TYPE=loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'
+				SESSION_TYPE=$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}')
 				echo $SESSION_TYPE
 				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -189,13 +189,14 @@ if [ "$firefoxuse" == "1" ] ; then
 
 	#install xdo tool
 	while [ -z "$xdoq" ] ; do
-		read -p "Install \"xdotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
+		read -p "Install \"xdotool\" or (\"ydotool\" on wayland) to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
 
 		if [ ! -z "$xdoq" ] ; then
 			if [[ "$xdoq" == "n" || "$xdoq" == "no" ]] ; then
 				echo "OK nevermind!"
 				break;
 				if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
+					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then
 						ydotool-manage install
@@ -207,6 +208,7 @@ if [ "$firefoxuse" == "1" ] ; then
 						echo "ydotool key 87:1 87:0" >> $MYSCRIPT
 					fi
 				else
+					echo "detected X-Server. Installing xdotool.."
 					if [ "$DISTRO" == "ubuntu" ]; then
 						apt install xdotool
 					else

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -187,19 +187,19 @@ if [ "$firefoxuse" == "1" ] ; then
 	echo "Placing desktop file at: $MYDESKTOPFILE"	
 	chown $response:$response -R /home/$response/.config/autostart/
 
-	#install ydo tool
-	while [ -z "$ydoq" ] ; do
-		read -p "Install \"ydotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" ydoq
+	#install xdo tool
+	while [ -z "$xdoq" ] ; do
+		read -p "Install \"xdotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
 
-		if [ ! -z "$ydoq" ] ; then
-			if [[ "$ydoq" == "y" || "$ydoq" == "yes" ]] ; then
+		if [ ! -z "$xdoq" ] ; then
+			if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
 				if [ "$DISTRO" == "ubuntu" ] ; then
-					apt install ydotool
+					apt install xdotool
 				else
 					yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-					yum -y install ydotool
+					yum -y install xdotool
 				fi
-			echo "ydotool key 69:1 69:0" >> $MYSCRIPT
+			echo "xdotool key \"F11\"" >> $MYSCRIPT
 			else	
 				echo "OK nevermind!"
 				break;

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,7 +196,7 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+				if [ $XDG_SESSION_TYPE == "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -197,7 +197,7 @@ if [ "$firefoxuse" == "1" ] ; then
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
 				echo $(whoami)
-				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$USERNAME" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
+				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$response" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
 				echo $SESSION_TYPE
 				echo "."
 				SESSION_TYPE=$XDG_SESSION_TYPE

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,11 +196,11 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				echo "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'"
+				echo loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'
 				echo "."
-				echo "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | sed 's/Type=//'"
+				echo loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | sed 's/Type=//'
 				echo ".."
-				SESSION_TYPE=$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}')
+				SESSION_TYPE=loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}'
 				echo $SESSION_TYPE
 				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,7 +196,10 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				if [ $XDG_SESSION_TYPE == "wayland" ]; then
+				echo $XDG_SESSION_TYPE
+				echo "."
+				echo "$XDG_SESSION_TYPE"
+				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -187,19 +187,19 @@ if [ "$firefoxuse" == "1" ] ; then
 	echo "Placing desktop file at: $MYDESKTOPFILE"	
 	chown $response:$response -R /home/$response/.config/autostart/
 
-	#install xdo tool
-	while [ -z "$xdoq" ] ; do
-		read -p "Install \"xdotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
+	#install ydo tool
+	while [ -z "$ydoq" ] ; do
+		read -p "Install \"ydotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" ydoq
 
-		if [ ! -z "$xdoq" ] ; then
-			if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
+		if [ ! -z "$ydoq" ] ; then
+			if [[ "$ydoq" == "y" || "$ydoq" == "yes" ]] ; then
 				if [ "$DISTRO" == "ubuntu" ] ; then
-					apt install xdotool
+					apt install ydotool
 				else
 					yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-					yum -y install xdotool
+					yum -y install ydotool
 				fi
-			echo "xdotool key \"F11\"" >> $MYSCRIPT
+			echo "ydotool key 69:1 69:0" >> $MYSCRIPT
 			else	
 				echo "OK nevermind!"
 				break;

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -199,7 +199,8 @@ if [ "$firefoxuse" == "1" ] ; then
 				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$USERNAME" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
 				echo $SESSION_TYPE
 				echo "."
-				echo $(loginctl show-session $(awk -v u="$USERNAME" '$0 ~ u{ print $1}'<<<$(loginctl)) -p Type | awk -F= '{print $2}')
+				SESSION_TYPE=$XDG_SESSION_TYPE
+				echo $SESSION_TYPE
 				echo ".."
 				SESSION_TYPE=$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}')
 				echo $SESSION_TYPE

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -192,17 +192,31 @@ if [ "$firefoxuse" == "1" ] ; then
 		read -p "Install \"xdotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
 
 		if [ ! -z "$xdoq" ] ; then
-			if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				if [ "$DISTRO" == "ubuntu" ] ; then
-					apt install xdotool
-				else
-					yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-					yum -y install xdotool
-				fi
-			echo "xdotool key \"F11\"" >> $MYSCRIPT
-			else	
+			if [[ "$xdoq" == "n" || "$xdoq" == "no" ]] ; then
 				echo "OK nevermind!"
 				break;
+				if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
+					chmod +x ydotool-manage
+					if [ "$DISTRO" == "ubuntu" ]; then
+						ydotool-manage install
+					else
+						echo " *** Untested variant. Please report if this works for your distro! ***"
+						ydotool-manage install
+					fi
+					if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
+						echo "ydotool key 87:1 87:0" >> $MYSCRIPT
+					fi
+				else
+					if [ "$DISTRO" == "ubuntu" ]; then
+						apt install xdotool
+					else
+						yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+						yum -y install xdotool
+					fi
+					if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
+						echo "xdotool key \"F11\"" >> $MYSCRIPT
+					fi
+				fi
 			fi
 		fi
 	done

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -146,7 +146,7 @@ done
 outputfile_autostart_script=$( cat << EOF 
 #!/bin/bash
 firefox --url \"$urlq\" &
-sleep 3;\n
+sleep 5;\n
 EOF
 )
 
@@ -189,20 +189,39 @@ if [ "$firefoxuse" == "1" ] ; then
 
 	#install xdo tool
 	while [ -z "$xdoq" ] ; do
-		read -p "Install \"xdotool\" to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
+		read -p "Install \"xdotool\" (or \"ydotool\" on wayland) to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
 
 		if [ ! -z "$xdoq" ] ; then
-			if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				if [ "$DISTRO" == "ubuntu" ] ; then
-					apt install xdotool
-				else
-					yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-					yum -y install xdotool
-				fi
-			echo "xdotool key \"F11\"" >> $MYSCRIPT
-			else	
+			if [[ "$xdoq" == "n" || "$xdoq" == "no" ]] ; then
 				echo "OK nevermind!"
 				break;
+			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
+				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$response" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
+				echo $SESSION_TYPE
+				if [ "$SESSION_TYPE" = "wayland" ]; then
+					echo "detected Wayland. Installing ydotool.."
+					chmod +x ydotool-manage
+					if [ "$DISTRO" == "ubuntu" ]; then
+						echo "use ydotool-manage install to install ydotool"
+						sh ydotool-manage install
+					else
+						echo " *** Untested variant. Please report if this works for your distro! ***"
+						echo "use ydotool-manage install to install ydotool"
+						sh ydotool-manage install
+					fi
+					echo "ydotool key 87:1 87:0" >> $MYSCRIPT
+				else
+					echo "detected X-Server. Installing xdotool.."
+					if [ "$DISTRO" == "ubuntu" ]; then
+						echo "use apt to install xdotool"
+						apt install xdotool
+					else
+						echo "use yum to install xdotool"
+						yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+						yum -y install xdotool
+					fi
+					echo "xdotool key \"F11\"" >> $MYSCRIPT
+				fi
 			fi
 		fi
 	done

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -189,7 +189,7 @@ if [ "$firefoxuse" == "1" ] ; then
 
 	#install xdo tool
 	while [ -z "$xdoq" ] ; do
-		read -p "Install \"xdotool\" or (\"ydotool\" on wayland) to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
+		read -p "Install \"xdotool\" (or \"ydotool\" on wayland) to simulate \"F11\" key press (for fullscreen browser)? (y/n):" xdoq
 
 		if [ ! -z "$xdoq" ] ; then
 			if [[ "$xdoq" == "n" || "$xdoq" == "no" ]] ; then

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,16 +196,9 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				echo $(whoami)
 				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$response" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
 				echo $SESSION_TYPE
-				echo "."
-				SESSION_TYPE=$XDG_SESSION_TYPE
-				echo $SESSION_TYPE
-				echo ".."
-				SESSION_TYPE=$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | awk -F= '{print $2}')
-				echo $SESSION_TYPE
-				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+				if [ "$SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,7 +196,7 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-				if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
+				if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -195,29 +195,30 @@ if [ "$firefoxuse" == "1" ] ; then
 			if [[ "$xdoq" == "n" || "$xdoq" == "no" ]] ; then
 				echo "OK nevermind!"
 				break;
+			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
 				if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
 					echo "detected Wayland. Installing ydotool.."
 					chmod +x ydotool-manage
 					if [ "$DISTRO" == "ubuntu" ]; then
-						ydotool-manage install
+						echo "use ydotool-manage install to install ydotool"
+						sh ydotool-manage install
 					else
 						echo " *** Untested variant. Please report if this works for your distro! ***"
-						ydotool-manage install
+						echo "use ydotool-manage install to install ydotool"
+						sh ydotool-manage install
 					fi
-					if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-						echo "ydotool key 87:1 87:0" >> $MYSCRIPT
-					fi
+					echo "ydotool key 87:1 87:0" >> $MYSCRIPT
 				else
 					echo "detected X-Server. Installing xdotool.."
 					if [ "$DISTRO" == "ubuntu" ]; then
+						echo "use apt to install xdotool"
 						apt install xdotool
 					else
+						echo "use yum to install xdotool"
 						yum -y install epel-release && rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
 						yum -y install xdotool
 					fi
-					if [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
-						echo "xdotool key \"F11\"" >> $MYSCRIPT
-					fi
+					echo "xdotool key \"F11\"" >> $MYSCRIPT
 				fi
 			fi
 		fi

--- a/kioskmode.sh
+++ b/kioskmode.sh
@@ -196,6 +196,7 @@ if [ "$firefoxuse" == "1" ] ; then
 				echo "OK nevermind!"
 				break;
 			elif  [[ "$xdoq" == "y" || "$xdoq" == "yes" ]] ; then
+				echo $(whoami)
 				SESSION_TYPE=$(loginctl show-session $(loginctl | awk -v u="$USERNAME" '$0 ~ u{ print $1 }') -p Type | awk -F= '{ print $2 }')
 				echo $SESSION_TYPE
 				echo "."

--- a/ydotool-manage
+++ b/ydotool-manage
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+if [ $# -ne 1 ] || ( [ "$1" != "start" ] && [ "$1" != "stop" ] && [ "$1" != "install" ] && [ "$1" != "status" ] );then
+    echo "`basename $0`: missing OPTION
+Usage: `basename $0` [OPTION]
+
+    '`basename $0` start' to start the ydotool service.
+    '`basename $0` stop' to stop the ydotool service
+    '`basename $0` install' to install (or update) ydotool."
+  exit 1
+fi
+
+# Visa status
+if [ "$1" = "status" ]; then
+    sudo systemctl status ydotool.service
+fi
+
+# Start ydtoold
+if [ "$1" = "start" ]; then
+    sudo systemctl start ydotool.service
+    sudo systemctl status ydotool.service
+fi
+
+# Stop ydtoold
+if [ "$1" = "stop" ]; then
+    sudo systemctl stop ydotool.service
+    sudo systemctl status ydotool.service
+fi
+
+# install (clone git folder, build and make install) ydotool and ydotoold.
+if [ "$1" = "install" ] ; then
+    sudo -v
+
+    # pre reqs
+    sudo apt update && sudo apt install cmake scdoc pkg-config
+
+    # Check if ydotool repo is downloaded
+    if [ ! -d /opt/ydotool ]; then 
+        cd /tmp
+        git clone https://github.com/ReimuNotMoe/ydotool.git
+        sudo mv /tmp/ydotool/ /opt/
+    fi
+
+    cd /opt/ydotool/
+
+    # Get latest version
+    git pull
+
+    # Make
+    mkdir -p build && cd build
+    cmake ..
+    make -j "$(nproc)"
+
+    # Install
+    sudo make install
+
+    # Remove the need for sudo
+    sudo chmod +s $(which ydotool)
+
+    # Install systemd service
+    sudo rm /etc/systemd/system/ydotool.service
+    sudo ln -s /usr/lib/systemd/user/ydotoold.service /etc/systemd/system/
+    # Reload the systemd daemon
+    sudo systemctl daemon-reload
+    # Reload enable the service
+    sudo systemctl enable ydotool
+    # Reload start ydotool
+    sudo systemctl start ydotool
+    # Check that it is running
+    sudo systemctl status ydotool
+
+    echo "ydotoold version: $(ydotoold --version)"
+    echo ""
+
+    if ! grep -q 'export YDOTOOL_SOCKET="/tmp/.ydotool_socket"' $HOME/.profile; then
+        echo '' >> "$HOME/.profile"
+        echo '# ydotoold socket location' >> "$HOME/.profile"
+        echo 'export YDOTOOL_SOCKET="/tmp/.ydotool_socket"' >> "$HOME/.profile"
+        echo "YDOTOOL_SOCKET is being exported in $HOME/.profile."
+        echo "Please relog to enable the new profile settings."
+    fi
+
+fi

--- a/ydotool-manage
+++ b/ydotool-manage
@@ -32,7 +32,7 @@ if [ "$1" = "install" ] ; then
     sudo -v
 
     # pre reqs
-    sudo apt update && sudo apt install cmake scdoc pkg-config
+    sudo apt update && sudo apt install cmake scdoc pkg-config -y
 
     # Check if ydotool repo is downloaded
     if [ ! -d /opt/ydotool ]; then 
@@ -58,16 +58,16 @@ if [ "$1" = "install" ] ; then
     sudo chmod +s $(which ydotool)
 
     # Install systemd service
-    sudo rm /etc/systemd/system/ydotool.service
+    sudo rm /etc/systemd/system/ydotoold.service
     sudo ln -s /usr/lib/systemd/user/ydotoold.service /etc/systemd/system/
     # Reload the systemd daemon
     sudo systemctl daemon-reload
     # Reload enable the service
-    sudo systemctl enable ydotool
+    sudo systemctl enable ydotoold
     # Reload start ydotool
-    sudo systemctl start ydotool
+    sudo systemctl start ydotoold
     # Check that it is running
-    sudo systemctl status ydotool
+    sudo systemctl status ydotoold
 
     echo "ydotoold version: $(ydotoold --version)"
     echo ""

--- a/ydotool-manage
+++ b/ydotool-manage
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+if [ $# -ne 1 ] || ( [ "$1" != "start" ] && [ "$1" != "stop" ] && [ "$1" != "install" ] && [ "$1" != "status" ] );then
+    echo "`basename $0`: missing OPTION
+Usage: `basename $0` [OPTION]
+
+    '`basename $0` start' to start the ydotool service.
+    '`basename $0` stop' to stop the ydotool service
+    '`basename $0` install' to install (or update) ydotool."
+  exit 1
+fi
+
+# Visa status
+if [ "$1" = "status" ]; then
+    sudo systemctl status ydotool.service
+fi
+
+# Start ydtoold
+if [ "$1" = "start" ]; then
+    sudo systemctl start ydotool.service
+    sudo systemctl status ydotool.service
+fi
+
+# Stop ydtoold
+if [ "$1" = "stop" ]; then
+    sudo systemctl stop ydotool.service
+    sudo systemctl status ydotool.service
+fi
+
+# install (clone git folder, build and make install) ydotool and ydotoold.
+if [ "$1" = "install" ] ; then
+    sudo -v
+
+    # pre reqs
+    sudo apt update && sudo apt install cmake scdoc pkg-config -y
+
+    # Check if ydotool repo is downloaded
+    if [ ! -d /opt/ydotool ]; then 
+        cd /tmp
+        git clone https://github.com/ReimuNotMoe/ydotool.git
+        sudo mv /tmp/ydotool/ /opt/
+    fi
+
+    cd /opt/ydotool/
+
+    # Get latest version
+    git pull
+
+    # Make
+    mkdir -p build && cd build
+    cmake ..
+    make -j "$(nproc)"
+
+    # Install
+    sudo make install
+
+    # Remove the need for sudo
+    sudo chmod +s $(which ydotool)
+
+    # Install systemd service
+    sudo rm /etc/systemd/system/ydotoold.service
+    sudo ln -s /usr/lib/systemd/user/ydotoold.service /etc/systemd/system/
+    # Reload the systemd daemon
+    sudo systemctl daemon-reload
+    # Reload enable the service
+    sudo systemctl enable ydotoold
+    # Reload start ydotool
+    sudo systemctl start ydotoold
+    # Check that it is running
+    sudo systemctl status ydotoold
+
+    echo "ydotoold version: $(ydotoold --version)"
+    echo ""
+
+    if ! grep -q 'export YDOTOOL_SOCKET="/tmp/.ydotool_socket"' $HOME/.profile; then
+        echo '' >> "$HOME/.profile"
+        echo '# ydotoold socket location' >> "$HOME/.profile"
+        echo 'export YDOTOOL_SOCKET="/tmp/.ydotool_socket"' >> "$HOME/.profile"
+        echo "YDOTOOL_SOCKET is being exported in $HOME/.profile."
+        echo "Please relog to enable the new profile settings."
+    fi
+
+fi


### PR DESCRIPTION
Because Ubuntu uses Wayland we have to switch the key tool. 
I managed to adopt a ydotool script and use it as installation helper as apt has an outdated version that does not work correctly.